### PR TITLE
snp.sh: Fix for measurement mismatch at attest-guest step

### DIFF
--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -99,7 +99,7 @@ SNPGUEST_BRANCH="tags/v0.3.2"
 NASM_SOURCE_TAR_URL="https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.gz"
 CLOUD_INIT_IMAGE_URL="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
 DRACUT_TARBALL_URL="https://github.com/dracutdevs/dracut/archive/refs/tags/059.tar.gz"
-SEV_SNP_MEASURE_VERSION="0.0.9"
+SEV_SNP_MEASURE_VERSION="0.0.8"
 
 
 


### PR DESCRIPTION
Updated sev-snp-measure version to 0.0.8 to resolve guest measurement mismatch for the stable SNP kernel commit version