### PR TITLE
SNP bit checks on the host and ubuntu guest from instruction set

### DIFF
--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -156,6 +156,21 @@ cleanup() {
   return $exit_code
 }
 
+verify_all_security_bits() {
+
+  local feature_error=''
+  for feature in "${!security_bit_values[@]}"
+  do
+    if [[ ${security_bit_values[$feature]} != 1 ]]; then
+        feature_error+=$(echo "${feature} bit value is ${security_bit_values[$feature]} .\n");
+    fi
+  done
+
+  if [[ -n "${feature_error}" ]]; then
+    echo ${feature_error}
+  fi
+}
+
 verify_snp_host() {
   if ! sudo dmesg | grep -i "SEV-SNP enabled\|SEV-SNP supported" 2>&1 >/dev/null; then
     echo -e "SEV-SNP not enabled on the host. Please follow these steps to enable:\n\


### PR DESCRIPTION
1. Added CPU check on the host for all host SEV features from cpuid 0x8000001f 
2. Added host SNP enablement check in BIOS from MSR 0xC0010010 bit 23 & 24
3. Added additional check on the guest to see if guest security bits are active from  MSR 0xc0010131 (MSR_AMD64_SEV)

I validated all the added checks in this PR  as follows:

-   Tested CPU support check for SNP on Rome, milan to check the CPU support check which works fine
-   Tested SNP enablement check in Bios which shows correct error message when SME/SNP are disabled in BIOS
-   Tested guest SEV/SEV-ES/SNP bit status on SNP guest and normal guest(w/o SNP enabled)



