### PR TITLE
Fix for error[E0282] issue at attest-guest step

### DIFF
--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -198,7 +198,7 @@ install_rust() {
   fi
 
   # Install rust
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -sSf | sh -s -- -y
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.70 -y
   source "${HOME}/.cargo/env" 2>/dev/null
 }
 


### PR DESCRIPTION
Downgraded latest rust installation to version 1.70 as a temporary fix to resolve error[E0282]: type annotations needed for `Box<_>` issue 