### PR TITLE
Fix for the SNP launch guest feature on 6.11.0-rc3 host

### DIFF
--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -271,6 +271,9 @@ install_dependencies() {
 
   # Needed to find information about CPU
   sudo apt install -y cpuid
+
+  # Needed to build 6.11.0-rc3 SNP kernel on the host
+  pip install tomli
   
   echo "true" > "${dependencies_installed_file}"
 }

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -585,7 +585,7 @@ build_base_qemu_cmdline() {
   add_qemu_cmdline_opts "-smp ${GUEST_SMP}"
   add_qemu_cmdline_opts "-m ${GUEST_MEM_SIZE_MB}M"
   add_qemu_cmdline_opts "-no-reboot"
-  add_qemu_cmdline_opts "-vga std"
+  add_qemu_cmdline_opts "-vga none"
   add_qemu_cmdline_opts "-monitor pty"
   add_qemu_cmdline_opts "-daemonize"
 
@@ -594,7 +594,7 @@ build_base_qemu_cmdline() {
   add_qemu_cmdline_opts "-device virtio-net-pci,disable-legacy=on,iommu_platform=true,netdev=vmnic,romfile="
 
   # Storage
-  add_qemu_cmdline_opts "-device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true"
+  add_qemu_cmdline_opts "-device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true,romfile="
   add_qemu_cmdline_opts "-device scsi-hd,drive=disk0"
   add_qemu_cmdline_opts "-drive if=none,id=disk0,format=qcow2,file=${IMAGE}"
 


### PR DESCRIPTION
This PR contains fix for the qemu memory issue during SNP guest lanch on 6.11.0-rc3 host.
(This resolves sev-utils issue: [https://github.com/amd/sev-utils/issues/17]())
