### PR TITLE
 Fix for submodule 'subhook' clone in AMDESE/OVMF

### DIFF
--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -670,6 +670,7 @@ build_and_install_amdsev() {
   [ ! -d "ovmf" ] || rm -rf "ovmf"
 
   # Build and copy files
+  git config --global url.https://github.com/Dasharo/subhook.insteadOf https://github.com/Zeex/subhook.git
   ./build.sh --package
   sudo cp kvm.conf /etc/modprobe.d/
   


### PR DESCRIPTION
Added workaround fix for time-being to build ovmf successfully without subhook GH inacessibility issue
More details can be found in this link(link: [here](https://github.com/AMDESE/ovmf/issues/8))