### PR TITLE
Optimize and create multiple SNP guests in the Ubuntu Host

### DIFF
--- a/docs/snp.md
+++ b/docs/snp.md
@@ -84,6 +84,12 @@ The `--non-upm` option can be specified with the above command if a non-upm vers
 of the kernel is desired. The `setup-host` command must be run with this same option 
 if launching the guest with a non-upm kernel.
 
+A user can launch separate SNP guests at the same time using unique guest name and guest qemu port.
+A user can set guest name and guest port with the `--guest-name` option and `--guest-port` option while the launch of a separate SNP guest as follows:
+```
+./snp.sh launch-guest --guest-name <user-guest-name> --guest-port <user-guest-port>
+```
+
 Attest the guest using the following command:
 ```
 ./snp.sh attest-guest
@@ -105,6 +111,10 @@ All script created guests can be stopped by running the following command:
 ./snp.sh stop-guests
 ```
 
+User created SNP guest via guest-name option can be stopped with the `--guest-name` option as follows:
+```
+./snp.sh stop-guests --guest-name <user-guest-name>
+```
 ## BYO Image
 
 The SNP script utility provides support for the user to provide their own image.

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -117,6 +117,8 @@ usage() {
   >&2 echo "  where OPTIONS are:"
   >&2 echo "    -n|--non-upm          Build AMDSEV non UPM kernel (sev-snp-devel)"
   >&2 echo "    -i|--image            Path to existing image file"
+  >&2 echo "    -g-n|--guest-name     Create a separate guest launch working directory"
+  >&2 echo "    -g-p|--guest-port     Set guest qemu port for networking"
   >&2 echo "    -h|--help             Usage information"
 
   return 1
@@ -1316,6 +1318,20 @@ main() {
       -i|--image)
         IMAGE="${2}"
         SKIP_IMAGE_CREATE=true
+        shift; shift
+        ;;
+
+      -g-n|--guest-name)
+        GUEST_NAME="${2}"
+        LAUNCH_WORKING_DIR="${LAUNCH_WORKING_DIR}/${GUEST_NAME}"
+        GUEST_SSH_KEY_PATH="${LAUNCH_WORKING_DIR}/${GUEST_NAME}-key"
+        QEMU_CMDLINE_FILE="${LAUNCH_WORKING_DIR}/qemu.cmdline"
+        IMAGE="${LAUNCH_WORKING_DIR}/${GUEST_NAME}.img"
+        shift; shift
+        ;;
+
+      -g-p|--guest-port)
+        HOST_SSH_PORT="${2}"
         shift; shift
         ;;
 

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -1412,7 +1412,7 @@ main() {
 
       echo -e "Guest SSH port forwarded to host port: ${HOST_SSH_PORT}"
       echo -e "The guest is running in the background. Use the following command to access via SSH:"
-      echo -e "ssh -p ${HOST_SSH_PORT} -i ${LAUNCH_WORKING_DIR}/snp-guest-key amd@localhost"
+      echo -e "ssh -p ${HOST_SSH_PORT} -i ${GUEST_SSH_KEY_PATH} ${GUEST_USER}@localhost"
       ;;
 
     attest-guest)


### PR DESCRIPTION
Users can launch multiple SNP enabled guests at the same time using --guest-name option and  export of HOST_SSH_PORT env. variables

Modified snp.sh to create a separate guest user directory and point the launch working directory to point the current specific guest user directory.

Enhanced the guest creation process via the download of base guest image from the URL once and re-use the same base guest image to create multiple SNP enabled guests.