### PR TITLE
SNP Guest Launch for Fedora and Ubuntu

### DIFF
--- a/docs/snp.md
+++ b/docs/snp.md
@@ -132,6 +132,12 @@ Launch the guest:
 ./snp.sh launch-guest
 ```
 
+User can launch various unique SNP enabled guests at the same time using
+ different GUEST_NAME and HOST_SSH_PORT environment variables. Export the following environment variables to achieve this:
+```
+export GUEST_NAME="guest-name"
+export HOST_SSH_PORT="your-host-SSH-port"
+```
 ## Accessing the Guest via SSH
 
 Once launched, the guest can be accessed with the following SSH command:

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -521,8 +521,8 @@ download_guest_os_image(){
 }
 
 cloud_init_create_data() {
-  if [[ -f "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/metadata.yaml" && \
-    -f "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/user-data.yaml"  && \
+  if [[ -f "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/meta-data" && \
+    -f "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/user-data"  && \
     -f "${IMAGE}" ]]; then
     echo -e "cloud-init data already generated"
     return 0
@@ -531,13 +531,13 @@ cloud_init_create_data() {
   local pub_key=$(cat "${GUEST_SSH_KEY_PATH}.pub")
 
 # Seed image metadata
-cat > "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/metadata.yaml" <<EOF
+cat > "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/meta-data" <<EOF
 instance-id: "${GUEST_NAME}"
 local-hostname: "${GUEST_NAME}"
 EOF
 
 # Seed image user data
-cat > "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/user-data.yaml" <<EOF
+cat > "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/user-data" <<EOF
 #cloud-config
 chpasswd:
   expire: false
@@ -554,7 +554,7 @@ users:
 EOF
 
   # Create the seed image with metadata and user data using genisoimage utility
-  genisoimage -output "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/ciiso.iso" -volid cidata -joliet -rock "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/user-data.yaml" "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/metadata.yaml"
+  genisoimage -output "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/ciiso.iso" -volid cidata -joliet -rock "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/user-data" "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-data/meta-data"
 
   # Download Guest Image from cloud init URL
   download_guest_os_image

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -1401,7 +1401,7 @@ main() {
 
       echo -e "Guest SSH port forwarded to host port: ${HOST_SSH_PORT}"
       echo -e "The guest is running in the background. Use the following command to access via SSH:"
-      echo -e "ssh -p ${HOST_SSH_PORT} -i ${LAUNCH_WORKING_DIR}/snp-guest-key amd@localhost"
+      echo -e "ssh -p ${HOST_SSH_PORT} -i ${GUEST_SSH_KEY_PATH} ${GUEST_USER}@localhost"
       ;;
 
     attest-guest)

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -87,6 +87,7 @@ GUEST_SSH_KEY_PATH="${GUEST_SSH_KEY_PATH:-${LAUNCH_WORKING_DIR}/${GUEST_NAME}-ke
 GUEST_ROOT_LABEL="${GUEST_ROOT_LABEL:-cloudimg-rootfs}"
 GUEST_KERNEL_APPEND="root=LABEL=${GUEST_ROOT_LABEL} ro console=ttyS0"
 QEMU_CMDLINE_FILE="${QEMU_CMDLINE:-${LAUNCH_WORKING_DIR}/qemu.cmdline}"
+BASE_CLOUD_IMAGE="${BASE_CLOUD_IMAGE:-${WORKING_DIR}/base_cloud_image.img}"
 IMAGE="${IMAGE:-${LAUNCH_WORKING_DIR}/${GUEST_NAME}.img}"
 GENERATED_INITRD_BIN="${SETUP_WORKING_DIR}/initrd.img"
 
@@ -540,7 +541,11 @@ EOF
     "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-metadata.yaml"
 
   # Download ubuntu 20.04 and change name
-  wget "${CLOUD_INIT_IMAGE_URL}" -O "${IMAGE}"
+  if [ ! -f "${BASE_CLOUD_IMAGE}" ]; then
+    wget "${CLOUD_INIT_IMAGE_URL}" -O "${BASE_CLOUD_IMAGE}"
+  fi
+
+  cp -v "${BASE_CLOUD_IMAGE}" "${IMAGE}"
 }
 
 resize_guest() {


### PR DESCRIPTION
This PR performs following tasks:

1. Launches various unique SNP enabled guests at the same time using different GUEST_NAME and HOST_SSH_PORT.
2. Creates a guest seed image having userdata and metadata for configuration using genisoimage utility(as this is supported across various linux distros).
3. Launches Fedora and Ubuntu SNP enabled guest.

