### PR TITLE
Support for RH SNP Guest launch on the RH host

### DIFF
--- a/docs/snp.md
+++ b/docs/snp.md
@@ -84,6 +84,12 @@ The `--non-upm` option can be specified with the above command if a non-upm vers
 of the kernel is desired. The `setup-host` command must be run with this same option 
 if launching the guest with a non-upm kernel.
 
+A user can launch separate SNP guests at the same time using unique guest name and guest qemu port.
+A user can set guest name and guest port with the `--guest-name` option and `--guest-port` option while the launch of a separate SNP guest as follows:
+```
+./snp.sh launch-guest --guest-name <user-guest-name> --guest-port <user-guest-port>
+```
+
 Attest the guest using the following command:
 ```
 ./snp.sh attest-guest
@@ -105,6 +111,10 @@ All script created guests can be stopped by running the following command:
 ./snp.sh stop-guests
 ```
 
+User created SNP guest via guest-name option can be stopped with the `--guest-name` option as follows:
+```
+./snp.sh stop-guests --guest-name <user-guest-name>
+```
 ## BYO Image
 
 The SNP script utility provides support for the user to provide their own image.

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -101,6 +101,8 @@ NASM_SOURCE_TAR_URL="https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.1
 CLOUD_INIT_IMAGE_URL="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
 CLOUD_INIT_IMAGE_URL_UBUNTU="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
 IMAGE_BASENAME_UBUNTU=$(basename "${CLOUD_INIT_IMAGE_URL_UBUNTU}")
+CLOUD_INIT_IMAGE_URL_FEDORA="https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+IMAGE_BASENAME_FEDORA=$(basename "${CLOUD_INIT_IMAGE_URL_FEDORA}")
 IMAGE_BASENAME=""
 GUEST_ROOT_LABEL_UBUNTU="cloudimg-rootfs"
 GUEST_KERNEL_APPEND_UBUNTU="root=LABEL=${GUEST_ROOT_LABEL_UBUNTU} ro console=ttyS0"
@@ -518,6 +520,20 @@ create_guest_seed_image(){
         "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-user-data.yaml" \
         "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-metadata.yaml"
       ;;
+    fedora)
+      mv -v "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-user-data.yaml" "${LAUNCH_WORKING_DIR}/user-data"
+      mv -v "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-metadata.yaml" "${LAUNCH_WORKING_DIR}/meta-data"
+
+      genisoimage -output "${SEED_IMAGE}" \
+        -volid cidata \
+        -joliet \
+        -rock \
+        "${LAUNCH_WORKING_DIR}/user-data" \
+        "${LAUNCH_WORKING_DIR}/meta-data"
+
+      mv -v "${LAUNCH_WORKING_DIR}/user-data" "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-user-data.yaml"
+      mv -v "${LAUNCH_WORKING_DIR}/meta-data" "${LAUNCH_WORKING_DIR}/${GUEST_NAME}-metadata.yaml"
+     ;;
     *)
       >&2 echo -e "ERROR: ${linux_distro}"
       return 1
@@ -533,6 +549,10 @@ download_guest_os_image(){
     ubuntu)
       CLOUD_INIT_IMAGE_URL=${CLOUD_INIT_IMAGE_URL_UBUNTU}
       IMAGE_BASENAME=${IMAGE_BASENAME_UBUNTU}
+      ;;
+    fedora)
+      CLOUD_INIT_IMAGE_URL=${CLOUD_INIT_IMAGE_URL_FEDORA}
+      IMAGE_BASENAME=${IMAGE_BASENAME_FEDORA}
       ;;
     *)
       >&2 echo -e "ERROR: ${linux_distro}"

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -1413,7 +1413,7 @@ main() {
 
       echo -e "Guest SSH port forwarded to host port: ${HOST_SSH_PORT}"
       echo -e "The guest is running in the background. Use the following command to access via SSH:"
-      echo -e "ssh -p ${HOST_SSH_PORT} -i ${LAUNCH_WORKING_DIR}/snp-guest-key amd@localhost"
+      echo -e "ssh -p ${HOST_SSH_PORT} -i ${GUEST_SSH_KEY_PATH} ${GUEST_USER}@localhost"
       ;;
 
     attest-guest)

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -131,8 +131,11 @@ usage() {
   >&2 echo "    -n|--non-upm          Build AMDSEV non UPM kernel (sev-snp-devel)"
   >&2 echo "    -i|--image            Path to existing image file"
   >&2 echo "    -r-i|--rhel-image     Path to existing red hat image file on red hat host"
+  >&2 echo "    -glwd|--guest-dir     Path to guest image launch working directory"
   >&2 echo "    -g-n|--guest-name     Create a separate guest launch working directory"
   >&2 echo "    -g-p|--guest-port     Set guest qemu port for networking"
+  >&2 echo "    -g-k|--guest-key-path Set guest SSH key path to access the guest"
+  >&2 echo "    -g-u|--guest-user     Set guest user name of the guest image"
   >&2 echo "    -h|--help             Usage information"
 
   return 1
@@ -1492,6 +1495,12 @@ main() {
         shift; shift
         ;;
 
+      -glwd|--guest-dir)
+        LAUNCH_WORKING_DIR="${2}"
+        QEMU_CMDLINE_FILE="${LAUNCH_WORKING_DIR}/qemu.cmdline"
+        shift; shift
+        ;;
+
       -g-n|--guest-name)
         GUEST_NAME="${2}"
         LAUNCH_WORKING_DIR="${LAUNCH_WORKING_DIR}/${GUEST_NAME}"
@@ -1504,6 +1513,16 @@ main() {
 
       -g-p|--guest-port)
         HOST_SSH_PORT="${2}"
+        shift; shift
+        ;;
+
+      -g-k|--guest-key-path)
+        GUEST_SSH_KEY_PATH="${2}"
+        shift; shift
+        ;;
+
+      -g-u|--guest-user)
+        GUEST_USER="${2}"
         shift; shift
         ;;
 

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -778,6 +778,12 @@ KERNEL_BIN="${guest_kernel}"
 EOF
 }
 
+guest_lauch_pre_cleanup() {
+  local guest_kernel_installed_file="${LAUNCH_WORKING_DIR}/guest_kernel_already_installed"
+  rm -rf "${guest_kernel_installed_file}"
+  rm -rf "${LAUNCH_WORKING_DIR}/source-bins"
+}
+
 copy_launch_binaries() {
   # Source the bins generated from setup
   source "${SETUP_WORKING_DIR}/source-bins"
@@ -1591,6 +1597,9 @@ main() {
         echo -e "Setup directory does not exist, please run 'setup-host' prior to 'launch-guest'"
         return 1
       fi
+
+      # Cleanup steps to enable SNP ubuntu/RH guest launch from the RHEL host
+      guest_lauch_pre_cleanup
 
       copy_launch_binaries
       source "${LAUNCH_WORKING_DIR}/source-bins"

--- a/tools/snp.sh
+++ b/tools/snp.sh
@@ -117,6 +117,8 @@ usage() {
   >&2 echo "  where OPTIONS are:"
   >&2 echo "    -n|--non-upm          Build AMDSEV non UPM kernel (sev-snp-devel)"
   >&2 echo "    -i|--image            Path to existing image file"
+  >&2 echo "    -g-n|--guest-name     Create a separate guest launch working directory"
+  >&2 echo "    -g-p|--guest-port     Set guest qemu port for networking"
   >&2 echo "    -h|--help             Usage information"
 
   return 1
@@ -1316,6 +1318,21 @@ main() {
       -i|--image)
         IMAGE="${2}"
         SKIP_IMAGE_CREATE=true
+        shift; shift
+        ;;
+
+      -g-n|--guest-name)
+        GUEST_NAME="${2}"
+        LAUNCH_WORKING_DIR="${LAUNCH_WORKING_DIR}/${GUEST_NAME}"
+        GUEST_SSH_KEY_PATH="${LAUNCH_WORKING_DIR}/${GUEST_NAME}-key"
+        QEMU_CMDLINE_FILE="${LAUNCH_WORKING_DIR}/qemu.cmdline"
+        IMAGE="${LAUNCH_WORKING_DIR}/${GUEST_NAME}.img"
+        SEED_IMAGE="${LAUNCH_WORKING_DIR}/${GUEST_NAME}-seed.img"
+        shift; shift
+        ;;
+
+      -g-p|--guest-port)
+        HOST_SSH_PORT="${2}"
         shift; shift
         ;;
 


### PR DESCRIPTION
User can launch SNP RH Guest on the RH host via the existing RHEL image using additional command options as follows:
```
./snp.sh launch-guest --rhel-image <existing RHEL image file path>  \
 --guest-dir <existing RHEL guest dir> \
--guest-port <RHEL guest port> \
--guest-key-path <RHEL guest SSH private key path>
--guest-user <RHEL guest user-name>
```

Built on top of PR #27 (PR to support Fedora SNP guest launch on Fedora host)

User can launch SNP ubuntu guest on the RH host if RHEL image doesn't exist using my forked branch `ubuntu-snp-gust-launch-rh-host` ([branch link here](https://github.com/LakshmiSaiHarika/sev-utils/tree/ubuntu-snp-gust-launch-rh-host))