### PR TITLE
Add flags to install latest kernel/tag during SNP host setup

### DIFF
--- a/docs/snp.md
+++ b/docs/snp.md
@@ -62,6 +62,18 @@ Setup the host by building SNP patched versions of qemu, ovmf and the linux kern
 The `--non-upm` option can be specified with the above command if a non-upm version 
 of the kernel is desired.
 
+The `--upstream-kernel` option can be specified with the above command if an upstream kernel version from the master branch is desired.
+
+```
+./snp.sh setup-host --upstream-kernel
+```
+
+The `--upstream-kernel-tag` option can be specified with the above command to install specific tag version from the upstream kernel:
+
+```
+./snp.sh setup-host --upstream-kernel-tag <specific kernel tag>
+```
+
 The above step will also change the default grub entry to the newly installed 
 host kernel.
 


### PR DESCRIPTION
User can install SNP kernel from the upstream kernel using this PR's new additional command options as follows:

1. User can install upstream SNP kernel from the master branch.
        `./snp.sh setup-host --upsteam-kernel `

2. User can install specific SNP kernel tagged version from the kernel upstream repository
        `./snp.sh setup-host --upstream-kernel-tag <specific kernel tag>`